### PR TITLE
Character Editor

### DIFF
--- a/addons/@fumohouse/character/camera_controller.gd
+++ b/addons/@fumohouse/character/camera_controller.gd
@@ -57,10 +57,12 @@ var _focus_distance := focus_distance
 
 
 func _ready():
-	_apply_fov()
-	_apply_sens_first_person()
-	_apply_sens_third_person()
-	_apply_zoom_sens()
+	# Defer to wait for ConfigManager to be ready (e.g., for the character
+	# preview in main.tscn)
+	_apply_fov.call_deferred()
+	_apply_sens_first_person.call_deferred()
+	_apply_sens_third_person.call_deferred()
+	_apply_zoom_sens.call_deferred()
 	_cm.value_changed.connect(_on_config_value_changed)
 
 

--- a/addons/@fumohouse/character_appearance/appearance.gd
+++ b/addons/@fumohouse/character_appearance/appearance.gd
@@ -7,9 +7,9 @@ extends Resource
 
 ## Global appearance configuration, such as facial appearance.
 @export var config: Dictionary[StringName, Variant] = {
-	&"eyebrows": &"",
-	&"eyes": &"",
-	&"mouth": &"",
+	&"eyebrows": null,
+	&"eyes": null,
+	&"mouth": null,
 	&"eyes_color": Color.WHITE,
 	&"scale": 1.0,
 }

--- a/addons/@fumohouse/character_appearance/appearance_manager.gd
+++ b/addons/@fumohouse/character_appearance/appearance_manager.gd
@@ -32,7 +32,7 @@ func load_appearance():
 	for id in appearance.attached_parts:
 		_attach(id)
 
-	for id in attached_parts:
+	for id in attached_parts.duplicate():
 		if appearance.attached_parts.has(id):
 			var config: Variant = appearance.attached_parts[id]
 

--- a/addons/@fumohouse/character_appearance/part_data.gd
+++ b/addons/@fumohouse/character_appearance/part_data.gd
@@ -19,6 +19,42 @@ enum Scope {
 	TAIL,
 }
 
+## Human-readable names for [enum Scope] values.
+const SCOPE_NAMES: Array[StringName] = [
+	"None",
+	"Accessory",
+	"Outfit (Full)",
+	"Outfit (Top)",
+	"Outfit (Bottom)",
+	"Hair (Full)",
+	"Hair (Front)",
+	"Hair (Back)",
+	"Hair (Accessory)",
+	"Shoes",
+	"Hat",
+	"Ears",
+	"Tail",
+]
+
+## Additional parameters for part slots. The value may contain the following
+## fields:[br]
+##
+## [code]multiple[/code] ([code]bool[/code], defaults to [code]false[/code]):
+## Whether selecting multiple parts for this slot should be allowed.[br]
+##
+## [code]exclude[/code] (Array[[enum Scope]], defaults to an empty array):
+## Array of scopes that should not be attachable if this slot is taken.
+const SLOT_PARAMS: Dictionary[Scope, Dictionary] = {
+	Scope.ACCESSORY: {"multiple": true},
+	Scope.HAIR_ACCESSORY: {"multiple": true},
+	Scope.HAIR_FULL: {"exclude": [Scope.HAIR_FRONT, Scope.HAIR_BACK]},
+	Scope.HAIR_FRONT: {"exclude": [Scope.HAIR_FULL]},
+	Scope.HAIR_BACK: {"exclude": [Scope.HAIR_FULL]},
+	Scope.OUTFIT_FULL: {"exclude": [Scope.OUTFIT_TOP, Scope.OUTFIT_BOTTOM]},
+	Scope.OUTFIT_TOP: {"exclude": [Scope.OUTFIT_FULL]},
+	Scope.OUTFIT_BOTTOM: {"exclude": [Scope.OUTFIT_FULL]},
+}
+
 ## The display name for this part.
 @export var display_name := ""
 

--- a/addons/@fumohouse/common/nodes/viewport_rect.gd
+++ b/addons/@fumohouse/common/nodes/viewport_rect.gd
@@ -1,0 +1,42 @@
+class_name ViewportRect
+extends TextureRect
+## A [TextureRect] displaying the contents of a [SubViewport].
+##
+## The [member viewport] is scaled according to the size of this node and of the
+## in-game window, and relevant [InputEvent]s received by this node are passed
+## on to it.
+
+## Disables handling of input events.
+@export var disable_input: bool = false
+## The viewport to display on the texture.
+@export var viewport: SubViewport
+
+
+func _ready():
+	texture = viewport.get_texture()
+
+	_scale_viewport()
+	get_window().size_changed.connect(_scale_viewport)
+	resized.connect(_scale_viewport)
+
+
+func _scale_viewport():
+	var window := get_window()
+	var scale := (window.size as Vector2) / (window.content_scale_size as Vector2)
+	viewport.size = size * max(scale.x, scale.y)
+
+
+func _gui_input(event: InputEvent):
+	if disable_input:
+		return
+
+	var window := get_window()
+	var scale := (window.size as Vector2) / (window.content_scale_size as Vector2)
+
+	if event is InputEventMouse:
+		event.position *= scale
+	if event is InputEventMouseMotion:
+		event.relative *= scale
+
+	viewport.push_input(event, true)
+	accept_event()

--- a/addons/@fumohouse/common/nodes/viewport_rect.gd.uid
+++ b/addons/@fumohouse/common/nodes/viewport_rect.gd.uid
@@ -1,0 +1,1 @@
+uid://cm0wscee4637m

--- a/addons/@fumohouse/fumo/character_editor/character_editor_custom.gd
+++ b/addons/@fumohouse/fumo/character_editor/character_editor_custom.gd
@@ -1,0 +1,27 @@
+extends Control
+
+const PartSelector := preload("part_selector.gd")
+const _SELECTOR_SCENE := preload("part_selector.tscn")
+
+@onready var _part_selectors: Container = %PartSelectors
+@onready var _scopes: OptionButton = %Scopes
+
+
+func _ready():
+	for scope: PartData.Scope in PartData.Scope.values().slice(1):
+		var part_selector: PartSelector = _SELECTOR_SCENE.instantiate()
+		part_selector.scope = scope
+		_part_selectors.add_child(part_selector)
+
+		_scopes.add_item(PartData.SCOPE_NAMES[scope])
+		_scopes.set_item_metadata(_scopes.item_count - 1, scope)
+
+	_scopes.item_selected.connect(_filter_section)
+
+
+func _filter_section(index: int):
+	var scope: Variant = _scopes.get_item_metadata(index)
+
+	for section: PartSelector in _part_selectors.get_children():
+		section.visible = scope == null or section.scope == scope
+		section.show_title(scope == null)

--- a/addons/@fumohouse/fumo/character_editor/character_editor_custom.gd.uid
+++ b/addons/@fumohouse/fumo/character_editor/character_editor_custom.gd.uid
@@ -1,0 +1,1 @@
+uid://dyxppsbxn5830

--- a/addons/@fumohouse/fumo/character_editor/character_editor_custom.tscn
+++ b/addons/@fumohouse/fumo/character_editor/character_editor_custom.tscn
@@ -1,0 +1,36 @@
+[gd_scene load_steps=3 format=3 uid="uid://bofgx233q1y7y"]
+
+[ext_resource type="Script" uid="uid://dyxppsbxn5830" path="res://addons/@fumohouse/fumo/character_editor/character_editor_custom.gd" id="1_t21bu"]
+[ext_resource type="Script" uid="uid://c2mo31oe5hccm" path="res://addons/@fumohouse/common/nodes/option_button_offset.gd" id="2_w5cad"]
+
+[node name="Custom" type="VBoxContainer"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/separation = 16
+script = ExtResource("1_t21bu")
+
+[node name="Scopes" type="OptionButton" parent="."]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(0, 41)
+layout_mode = 2
+selected = 0
+item_count = 1
+popup/item_0/text = "All"
+popup/item_0/id = 0
+script = ExtResource("2_w5cad")
+metadata/_custom_type_script = "uid://c2mo31oe5hccm"
+
+[node name="ScrollContainer" type="ScrollContainer" parent="."]
+layout_mode = 2
+size_flags_vertical = 3
+horizontal_scroll_mode = 0
+
+[node name="PartSelectors" type="VBoxContainer" parent="ScrollContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_constants/separation = 16

--- a/addons/@fumohouse/fumo/character_editor/character_editor_presets.gd
+++ b/addons/@fumohouse/fumo/character_editor/character_editor_presets.gd
@@ -1,0 +1,30 @@
+extends Control
+
+@onready var _fumo_appearances: FumoAppearances = FumoAppearances.get_singleton()
+
+@onready var _grid: GridContainer = %Grid
+@onready var _search_edit: LineEdit = %SearchEdit
+
+
+func _ready():
+	_update_presets()
+	_search_edit.text_changed.connect(_filter_presets)
+
+
+func _stage_appearance(appearance: Appearance):
+	_fumo_appearances.staging = appearance.duplicate(true)
+	_fumo_appearances.staging_changed.emit()
+
+
+func _update_presets():
+	for appearance in _fumo_appearances.presets:
+		var button := Button.new()
+		button.text = appearance.display_name
+		button.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		button.pressed.connect(_stage_appearance.bind(appearance))
+		_grid.add_child(button)
+
+
+func _filter_presets(query: String):
+	for button: Button in _grid.get_children():
+		button.visible = query.is_empty() or button.text.containsn(query)

--- a/addons/@fumohouse/fumo/character_editor/character_editor_presets.gd.uid
+++ b/addons/@fumohouse/fumo/character_editor/character_editor_presets.gd.uid
@@ -1,0 +1,1 @@
+uid://b8twh8hujumqe

--- a/addons/@fumohouse/fumo/character_editor/character_editor_presets.tscn
+++ b/addons/@fumohouse/fumo/character_editor/character_editor_presets.tscn
@@ -1,0 +1,25 @@
+[gd_scene load_steps=2 format=3 uid="uid://4gntby41idbe"]
+
+[ext_resource type="Script" uid="uid://b8twh8hujumqe" path="res://addons/@fumohouse/fumo/character_editor/character_editor_presets.gd" id="1_oycch"]
+
+[node name="Presets" type="VBoxContainer"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/separation = 16
+script = ExtResource("1_oycch")
+
+[node name="SearchEdit" type="LineEdit" parent="."]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(0, 41)
+layout_mode = 2
+size_flags_horizontal = 3
+placeholder_text = "Search..."
+
+[node name="Grid" type="GridContainer" parent="."]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_vertical = 3
+columns = 4

--- a/addons/@fumohouse/fumo/character_editor/character_editor_preview.gd
+++ b/addons/@fumohouse/fumo/character_editor/character_editor_preview.gd
@@ -1,0 +1,57 @@
+extends VBoxContainer
+
+const CharacterViewport := preload(
+	"res://addons/@fumohouse/fumo/character_editor/character_viewport.gd"
+)
+
+@onready var _fumo_appearances: FumoAppearances = FumoAppearances.get_singleton()
+
+@onready var _character_name: LineEdit = %CharacterName
+@onready var _character_viewport: CharacterViewport = %CharacterViewport
+@onready var _apply_button: Button = %ApplyButton
+
+@onready var _scale_slider: HSlider = %ScaleSlider
+@onready var _scale_label: Label = %ScaleLabel
+@onready var _scale_presets: Node = %ScalePresets
+
+
+func _ready():
+	_update()
+	_fumo_appearances.staging_changed.connect(_update)
+
+	_apply_button.pressed.connect(_fumo_appearances.apply)
+
+	_character_name.text_changed.connect(_update_name)
+	_scale_slider.value_changed.connect(_update_scale)
+
+	for button: Button in _scale_presets.get_children():
+		var scale: float = button.get_meta("scale_preset")
+		if not scale:
+			continue
+
+		button.pressed.connect(_update_scale.bind(scale))
+
+
+func _update():
+	var appearance := _fumo_appearances.staging
+	# Avoid cursor movement when setting same text
+	if _character_name.text != appearance.display_name:
+		_character_name.text = appearance.display_name
+
+	var scale = appearance.config.get(&"scale")
+	_scale_label.text = "%.f%%" % (scale * 100)
+	# does not appear to cause a circular dependency as value_changed doesn't fire back to this
+	_scale_slider.value = scale
+
+	_character_viewport.character.appearance_manager.appearance = _fumo_appearances.staging
+	_character_viewport.character.appearance_manager.load_appearance()
+
+
+func _update_name(new_name: String):
+	_fumo_appearances.staging.display_name = new_name
+	_fumo_appearances.staging_changed.emit()
+
+
+func _update_scale(scale: float):
+	_fumo_appearances.staging.config.set(&"scale", scale)
+	_fumo_appearances.staging_changed.emit()

--- a/addons/@fumohouse/fumo/character_editor/character_editor_preview.gd.uid
+++ b/addons/@fumohouse/fumo/character_editor/character_editor_preview.gd.uid
@@ -1,0 +1,1 @@
+uid://dvryl7jn8lghl

--- a/addons/@fumohouse/fumo/character_editor/character_editor_preview.tscn
+++ b/addons/@fumohouse/fumo/character_editor/character_editor_preview.tscn
@@ -1,0 +1,95 @@
+[gd_scene load_steps=4 format=3 uid="uid://b8w13u5smtchn"]
+
+[ext_resource type="Script" uid="uid://dvryl7jn8lghl" path="res://addons/@fumohouse/fumo/character_editor/character_editor_preview.gd" id="1_eik25"]
+[ext_resource type="FontFile" uid="uid://b84oqonqechq2" path="res://addons/@fumohouse/base/assets/fonts/clarity_city/ClarityCity-Bold.woff2" id="2_5hlcs"]
+[ext_resource type="PackedScene" uid="uid://d4hwbq0e54jt4" path="res://addons/@fumohouse/fumo/character_editor/character_viewport.tscn" id="3_6ouxl"]
+
+[node name="CharacterEditorPreview" type="VBoxContainer"]
+custom_minimum_size = Vector2(292, 0)
+offset_right = 292.0
+offset_bottom = 365.0
+script = ExtResource("1_eik25")
+
+[node name="HBoxContainer" type="HBoxContainer" parent="."]
+layout_mode = 2
+
+[node name="CharacterName" type="LineEdit" parent="HBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_fonts/font = ExtResource("2_5hlcs")
+theme_override_font_sizes/font_size = 20
+text = "Character"
+
+[node name="ApplyButton" type="Button" parent="HBoxContainer"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(41, 41)
+layout_mode = 2
+tooltip_text = "Apply"
+text = ""
+
+[node name="CharacterViewport" parent="." instance=ExtResource("3_6ouxl")]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="Scale" type="VBoxContainer" parent="."]
+layout_mode = 2
+
+[node name="Title" type="HBoxContainer" parent="Scale"]
+layout_mode = 2
+
+[node name="ScaleTitle" type="Label" parent="Scale/Title"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_fonts/font = ExtResource("2_5hlcs")
+text = "Character Scale"
+
+[node name="ScaleLabel" type="Label" parent="Scale/Title"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "0%"
+horizontal_alignment = 2
+vertical_alignment = 1
+
+[node name="ScaleSlider" type="HSlider" parent="Scale"]
+unique_name_in_owner = true
+layout_mode = 2
+min_value = 0.5
+max_value = 3.0
+step = 0.05
+value = 1.0
+
+[node name="ScalePresets" type="HBoxContainer" parent="Scale"]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="Doll" type="Button" parent="Scale/ScalePresets"]
+custom_minimum_size = Vector2(70, 0)
+layout_mode = 2
+theme_override_font_sizes/font_size = 15
+text = "Doll"
+metadata/scale_preset = 0.5
+
+[node name="Shinmy" type="Button" parent="Scale/ScalePresets"]
+custom_minimum_size = Vector2(70, 0)
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_font_sizes/font_size = 14
+text = "Shinmy"
+metadata/scale_preset = 0.75
+
+[node name="Base" type="Button" parent="Scale/ScalePresets"]
+custom_minimum_size = Vector2(70, 0)
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_font_sizes/font_size = 15
+text = "Base"
+metadata/scale_preset = 1.0
+
+[node name="Deka" type="Button" parent="Scale/ScalePresets"]
+custom_minimum_size = Vector2(70, 0)
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_font_sizes/font_size = 15
+text = "Deka"
+metadata/scale_preset = 2.0

--- a/addons/@fumohouse/fumo/character_editor/character_viewport.gd
+++ b/addons/@fumohouse/fumo/character_editor/character_viewport.gd
@@ -1,0 +1,13 @@
+extends ViewportRect
+
+@onready var character: Fumo = %Fumo
+@onready var _camera_controller: CameraController = %CameraController
+
+
+func _ready():
+	super()
+
+	_camera_controller.camera_rotation.y = PI
+
+	character.appearance_manager.base_camera_offset = 2.0
+	character.camera = _camera_controller

--- a/addons/@fumohouse/fumo/character_editor/character_viewport.gd.uid
+++ b/addons/@fumohouse/fumo/character_editor/character_viewport.gd.uid
@@ -1,0 +1,1 @@
+uid://de12x0b5vb43n

--- a/addons/@fumohouse/fumo/character_editor/character_viewport.tscn
+++ b/addons/@fumohouse/fumo/character_editor/character_viewport.tscn
@@ -1,0 +1,63 @@
+[gd_scene load_steps=6 format=3 uid="uid://d4hwbq0e54jt4"]
+
+[ext_resource type="Script" uid="uid://de12x0b5vb43n" path="res://addons/@fumohouse/fumo/character_editor/character_viewport.gd" id="1_hbyoh"]
+[ext_resource type="Script" uid="uid://ck70ouuqfwjvq" path="res://addons/@fumohouse/character/camera_controller.gd" id="3_phe1h"]
+[ext_resource type="PackedScene" uid="uid://bnic23uqggm8j" path="res://addons/@fumohouse/fumo/fumo.tscn" id="6_hjhjk"]
+
+[sub_resource type="Environment" id="Environment_nu2qa"]
+ambient_light_source = 2
+ambient_light_color = Color(1, 1, 1, 1)
+ambient_light_energy = 0.25
+
+[sub_resource type="World3D" id="World3D_nu2qa"]
+environment = SubResource("Environment_nu2qa")
+
+[node name="CharacterViewport" type="TextureRect" node_paths=PackedStringArray("viewport")]
+custom_minimum_size = Vector2(240, 240)
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+expand_mode = 1
+script = ExtResource("1_hbyoh")
+viewport = NodePath("SubViewport")
+
+[node name="SubViewport" type="SubViewport" parent="."]
+unique_name_in_owner = true
+own_world_3d = true
+world_3d = SubResource("World3D_nu2qa")
+transparent_bg = true
+handle_input_locally = false
+size = Vector2i(1152, 648)
+render_target_update_mode = 4
+
+[node name="Camera3D" type="Camera3D" parent="SubViewport"]
+transform = Transform3D(-1, 0, -8.742278e-08, 0, 1, 0, 8.742278e-08, 0, -1, 0, 0, -3)
+current = true
+
+[node name="CameraController" type="Node3D" parent="SubViewport/Camera3D" node_paths=PackedStringArray("camera", "focus_node")]
+unique_name_in_owner = true
+transform = Transform3D(-1, 0, 8.742278e-08, 0, 1, 0, -8.742278e-08, 0, -1, 2.6226832e-07, -1.75, -3)
+script = ExtResource("3_phe1h")
+camera = NodePath("..")
+camera_offset = 1.75
+min_focus_distance = 2.0
+max_focus_distance = 8.0
+focus_distance = 3.0
+move_speed_fast = 24.0
+focus_node = NodePath("../../Fumo")
+metadata/_custom_type_script = "uid://ck70ouuqfwjvq"
+
+[node name="DirectionalLight3D" type="DirectionalLight3D" parent="SubViewport"]
+transform = Transform3D(0.86602557, 0.28678808, 0.40957582, -1.2368851e-07, -0.81915194, 0.57357657, 0.49999973, -0.49673203, -0.7094065, 0, 8, 0)
+light_color = Color(1, 0.99607843, 0.92941177, 1)
+
+[node name="Fumo" parent="SubViewport" instance=ExtResource("6_hjhjk")]
+unique_name_in_owner = true
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -1.75, 0)
+camera_fade_begin = 0.0
+camera_fade_end = 0.0
+disabled = true

--- a/addons/@fumohouse/fumo/character_editor/part_preview_button.gd
+++ b/addons/@fumohouse/fumo/character_editor/part_preview_button.gd
@@ -1,0 +1,29 @@
+extends Button
+
+const CharacterViewport := preload("character_viewport.gd")
+
+@export var part: PartData
+
+@onready var character_viewport: CharacterViewport = %CharacterViewport
+@onready var indicator: Panel = %Indicator
+
+@onready var _fumo_appearances: FumoAppearances = FumoAppearances.get_singleton()
+
+
+func _ready():
+	var appearance := Appearance.new()
+	character_viewport.character.appearance_manager.appearance = appearance
+
+	# Wait until the preview is visible before loading any assets.
+	await draw
+
+	appearance.attached_parts[part.id] = part.default_config
+	character_viewport.character.appearance_manager.load_appearance()
+	character_viewport.character.set_rig_alpha(0.0)
+
+	_update_indicator()
+	_fumo_appearances.staging_changed.connect(_update_indicator)
+
+
+func _update_indicator():
+	indicator.visible = _fumo_appearances.staging.attached_parts.has(part.id)

--- a/addons/@fumohouse/fumo/character_editor/part_preview_button.gd.uid
+++ b/addons/@fumohouse/fumo/character_editor/part_preview_button.gd.uid
@@ -1,0 +1,1 @@
+uid://c1yow7f6dajs0

--- a/addons/@fumohouse/fumo/character_editor/part_preview_button.tscn
+++ b/addons/@fumohouse/fumo/character_editor/part_preview_button.tscn
@@ -1,0 +1,45 @@
+[gd_scene load_steps=5 format=3 uid="uid://nrt2nygsisgy"]
+
+[ext_resource type="PackedScene" uid="uid://d4hwbq0e54jt4" path="res://addons/@fumohouse/fumo/character_editor/character_viewport.tscn" id="1_anwhb"]
+[ext_resource type="Script" uid="uid://c1yow7f6dajs0" path="res://addons/@fumohouse/fumo/character_editor/part_preview_button.gd" id="1_gxlyi"]
+[ext_resource type="Resource" uid="uid://cjqguoqnnotml" path="res://addons/@fumohouse/fumo_models/resources/part_data/doremy/doremy_outfit.tres" id="2_7nr2o"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_anwhb"]
+bg_color = Color(0.44705883, 0.9607843, 0.35686275, 1)
+corner_radius_top_left = 6
+corner_radius_top_right = 6
+corner_radius_bottom_right = 6
+corner_radius_bottom_left = 6
+
+[node name="PartPreviewButton" type="Button"]
+custom_minimum_size = Vector2(150, 150)
+offset_right = 150.0
+offset_bottom = 150.0
+script = ExtResource("1_gxlyi")
+part = ExtResource("2_7nr2o")
+
+[node name="CharacterViewport" parent="." instance=ExtResource("1_anwhb")]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(150, 150)
+layout_mode = 0
+anchors_preset = 0
+anchor_right = 0.0
+anchor_bottom = 0.0
+offset_right = 150.0
+offset_bottom = 150.0
+grow_horizontal = 1
+grow_vertical = 1
+disable_input = true
+
+[node name="Indicator" type="Panel" parent="."]
+unique_name_in_owner = true
+layout_mode = 1
+anchors_preset = 1
+anchor_left = 1.0
+anchor_right = 1.0
+offset_left = -22.0
+offset_top = 10.0
+offset_right = -10.0
+offset_bottom = 22.0
+grow_horizontal = 0
+theme_override_styles/panel = SubResource("StyleBoxFlat_anwhb")

--- a/addons/@fumohouse/fumo/character_editor/part_selector.gd
+++ b/addons/@fumohouse/fumo/character_editor/part_selector.gd
@@ -1,0 +1,57 @@
+extends Control
+
+const PartPreviewButton := preload("part_preview_button.gd")
+const _BUTTON_SCENE := preload("part_preview_button.tscn")
+
+@export var scope: PartData.Scope
+
+var _multiple: bool = false
+var _exclude: Array = []
+
+@onready var _fumo_appearances: FumoAppearances = FumoAppearances.get_singleton()
+@onready var _part_database: FumoPartDatabase = FumoPartDatabase.get_singleton()
+
+@onready var _grid: GridContainer = %Grid
+@onready var _title: Label = %Title
+
+
+func _ready():
+	_title.text = PartData.SCOPE_NAMES[scope]
+	_config_slot()
+
+	for part in _part_database.parts.values():
+		if part.scope != scope:
+			continue
+
+		var button: PartPreviewButton = _BUTTON_SCENE.instantiate()
+		button.part = part
+		button.pressed.connect(_set_part.bind(part))
+		_grid.add_child(button)
+
+
+func show_title(vis: bool):
+	_title.visible = vis
+
+
+func _config_slot():
+	var params := PartData.SLOT_PARAMS.get(scope)
+
+	if params:
+		_multiple = params.get("multiple", _multiple)
+		_exclude = params.get("exclude", _exclude)
+
+
+func _set_part(part_data: PartData):
+	for key in _fumo_appearances.staging.attached_parts.keys():
+		var attached := _part_database.get_part(key)
+
+		if (
+			((attached.scope == part_data.scope and not _multiple) or _exclude.has(attached.scope))
+			and attached.id != part_data.id
+		):
+			_fumo_appearances.staging.attached_parts.erase(attached.id)
+
+	if not _fumo_appearances.staging.attached_parts.erase(part_data.id):
+		_fumo_appearances.staging.attached_parts[part_data.id] = null
+
+	_fumo_appearances.staging_changed.emit()

--- a/addons/@fumohouse/fumo/character_editor/part_selector.gd.uid
+++ b/addons/@fumohouse/fumo/character_editor/part_selector.gd.uid
@@ -1,0 +1,1 @@
+uid://bd3wjonch3k7i

--- a/addons/@fumohouse/fumo/character_editor/part_selector.tscn
+++ b/addons/@fumohouse/fumo/character_editor/part_selector.tscn
@@ -1,0 +1,19 @@
+[gd_scene load_steps=2 format=3 uid="uid://d3nmdhmyuyk8n"]
+
+[ext_resource type="Script" uid="uid://bd3wjonch3k7i" path="res://addons/@fumohouse/fumo/character_editor/part_selector.gd" id="1_mb8im"]
+
+[node name="PartSelector" type="VBoxContainer"]
+offset_right = 67.0
+offset_bottom = 20.0
+theme_override_constants/separation = 4
+script = ExtResource("1_mb8im")
+
+[node name="Title" type="Label" parent="."]
+unique_name_in_owner = true
+layout_mode = 2
+text = "(Section)"
+
+[node name="Grid" type="GridContainer" parent="."]
+unique_name_in_owner = true
+layout_mode = 2
+columns = 4

--- a/addons/@fumohouse/fumo/fumo_appearance_manager.gd
+++ b/addons/@fumohouse/fumo/fumo_appearance_manager.gd
@@ -34,6 +34,9 @@ func _ready():
 
 ## Get the scale set by [member appearance].
 func get_appearance_scale() -> float:
+	if not appearance:
+		return 1.0
+
 	var scale: Variant = appearance.config.get(&"scale")
 	return scale if scale is float else 1.0
 

--- a/addons/@fumohouse/fumo/fumo_appearances.gd
+++ b/addons/@fumohouse/fumo/fumo_appearances.gd
@@ -1,0 +1,62 @@
+class_name FumoAppearances
+extends Node
+## Singleton to keep track of Fumo appearance presets and to manage presets for
+## the local character.
+##
+## Keeps track of active and staging appearances, to use in-game and when
+## editing respectively.
+
+## Emitted after [member active] changes.
+signal active_changed
+## Emitted after [member staging] changes.
+signal staging_changed
+
+## Current appearance for local character
+##
+## After modifying this value or its fields, it is recommended to emit the
+## [signal active_changed] signal to notify listeners.
+var active: Appearance = preload(
+	"res://addons/@fumohouse/fumo_models/resources/presets/doremy.tres"
+)
+
+## Preview appearance to be applied.
+##
+## After modifying this value or its fields, it is recommended to emit the
+## [signal staging_changed] signal to notify listeners.
+var staging: Appearance = active.duplicate(true)
+
+## List of presets available.
+var presets: Array[Appearance]
+
+
+## Get the singleton instance for this node.
+static func get_singleton() -> FumoAppearances:
+	return Modules.get_singleton(&"FumoAppearances") as FumoAppearances
+
+
+func _ready():
+	scan_dir("res://addons/@fumohouse/fumo_models/resources/presets")
+
+	presets.sort_custom(func(a: Appearance, b: Appearance): return a.display_name < b.display_name)
+
+
+## Scan [param path] recursively for model presets.
+func scan_dir(path: String):
+	for entry in ResourceLoader.list_directory(path):
+		var full_path := path.path_join(entry)
+		if entry.ends_with("/"):
+			scan_dir(full_path)
+			continue
+
+		var preset := load(full_path) as Appearance
+		if not preset:
+			push_warning("Unrecognized preset: '%s'." % full_path)
+			continue
+
+		presets.push_back(preset)
+
+
+## Apply active [Appearance] by copying from staging.
+func apply():
+	active = staging.duplicate(true)
+	active_changed.emit()

--- a/addons/@fumohouse/fumo/fumo_appearances.gd.uid
+++ b/addons/@fumohouse/fumo/fumo_appearances.gd.uid
@@ -1,0 +1,1 @@
+uid://lyewi760b52y

--- a/addons/@fumohouse/fumo/module.tres
+++ b/addons/@fumohouse/fumo/module.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" script_class="ModuleManifest" load_steps=9 format=3 uid="uid://cefvip8wn7vbo"]
+[gd_resource type="Resource" script_class="ModuleManifest" load_steps=10 format=3 uid="uid://cefvip8wn7vbo"]
 
 [ext_resource type="Script" uid="uid://bv6m4s88g0oi6" path="res://addons/@fumohouse/base/module_autoload.gd" id="1_fji1f"]
 [ext_resource type="Script" uid="uid://cyriemmrcefgc" path="res://addons/@fumohouse/base/module_dependency.gd" id="2_wcwlm"]
@@ -8,6 +8,12 @@
 script = ExtResource("1_fji1f")
 name = &"FumoPartDatabase"
 path = "uid://chk610exuabgj"
+metadata/_custom_type_script = "uid://bv6m4s88g0oi6"
+
+[sub_resource type="Resource" id="Resource_xkmxm"]
+script = ExtResource("1_fji1f")
+name = &"FumoAppearances"
+path = "uid://lyewi760b52y"
 metadata/_custom_type_script = "uid://bv6m4s88g0oi6"
 
 [sub_resource type="Resource" id="Resource_fji1f"]
@@ -33,5 +39,5 @@ metadata/_custom_type_script = "uid://cyriemmrcefgc"
 [resource]
 script = ExtResource("3_bvh68")
 dependencies = Array[ExtResource("2_wcwlm")]([SubResource("Resource_fji1f"), SubResource("Resource_4mx1m"), SubResource("Resource_ryamt"), SubResource("Resource_0g7ck")])
-autoloads = Array[ExtResource("1_fji1f")]([SubResource("Resource_chw3y")])
+autoloads = Array[ExtResource("1_fji1f")]([SubResource("Resource_chw3y"), SubResource("Resource_xkmxm")])
 metadata/_custom_type_script = "uid://c5kqgift21f1k"

--- a/addons/@fumohouse/fumo_models/resources/part_data/generic/socks_1.tres
+++ b/addons/@fumohouse/fumo_models/resources/part_data/generic/socks_1.tres
@@ -23,4 +23,7 @@ parts = Array[ExtResource("1_0o6vt")]([SubResource("Resource_0o6vt"), SubResourc
 display_name = "Socks 1"
 id = &"socks_1"
 scope = 1
+default_config = Dictionary[StringName, Variant]({
+&"color": Color(1, 1, 1, 1)
+})
 metadata/_custom_type_script = "uid://dgvlk6ce324r2"

--- a/addons/@fumohouse/fumo_models/resources/part_data/momiji/momiji_hat.tres
+++ b/addons/@fumohouse/fumo_models/resources/part_data/momiji/momiji_hat.tres
@@ -9,3 +9,4 @@ transform = Transform3D(-1, 9.933157e-10, -3.8895726e-07, 5.593243e-09, 0.999930
 bone = "Head"
 display_name = "Momiji Hat"
 id = &"momiji_hat"
+scope = 10

--- a/addons/@fumohouse/main/main.gd
+++ b/addons/@fumohouse/main/main.gd
@@ -1,6 +1,10 @@
 class_name MainMenu  # for typing of _get_main_scene etc.
 extends "res://addons/@fumohouse/navigation/nav_menu.gd"
 
+const NavCharacter := preload(
+	"res://addons/@fumohouse/navigation/character_editor/nav_character.gd"
+)
+
 var transition_in := true
 
 @onready var _dim: ColorRect = $Dim
@@ -9,8 +13,11 @@ var transition_in := true
 @onready var _options_button: Button = %OptionsButton
 @onready var _exit_button: Button = %ExitButton
 
+@onready var _nav_character: NavCharacter = %NavCharacter
+
 @onready var _play_screen: TransitionElement = $Screens/PlayScreen
 @onready var _options_screen: TransitionElement = $Screens/OptionsScreen
+@onready var _char_edit_screen: TransitionElement = $Screens/CharacterEditorScreen
 
 @onready var _wm := WorldManager.get_singleton()
 
@@ -50,6 +57,8 @@ func _ready():
 	_play_button.pressed.connect(func(): switch_screen(_play_screen))
 	_options_button.pressed.connect(func(): switch_screen(_options_screen))
 	_exit_button.pressed.connect(_on_exit_button_pressed)
+
+	_nav_character.edit_pressed.connect(switch_screen.bind(_char_edit_screen))
 
 	_wm.get_main_scene = _get_main_scene
 	_wm.prepare_main_scene = _prepare_main_scene

--- a/addons/@fumohouse/main/main.tscn
+++ b/addons/@fumohouse/main/main.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=21 format=3 uid="uid://r3htqql86m4u"]
+[gd_scene load_steps=23 format=3 uid="uid://r3htqql86m4u"]
 
 [ext_resource type="PackedScene" uid="uid://ctxaywfcdgbmw" path="res://addons/@fumohouse/navigation/nav_menu.tscn" id="1_emt38"]
 [ext_resource type="Script" uid="uid://donqdlntewiwc" path="res://addons/@fumohouse/main/main.gd" id="2_3w01d"]
 [ext_resource type="Texture2D" uid="uid://cdxg2w1khoiq4" path="res://addons/@fumohouse/base/assets/textures/faces_bg.svg" id="3_lqqwp"]
 [ext_resource type="PackedScene" uid="uid://cce2lc4hx05ok" path="res://addons/@fumohouse/main/ui/play_screen/play_screen.tscn" id="4_3w01d"]
 [ext_resource type="PackedScene" uid="uid://c55ax8y8twfnj" path="res://addons/@fumohouse/navigation/options_screen/options_screen.tscn" id="4_eq6r0"]
+[ext_resource type="PackedScene" uid="uid://bdohqbssyckea" path="res://addons/@fumohouse/navigation/character_editor/character_editor.tscn" id="5_eq6r0"]
 [ext_resource type="Script" uid="uid://beubs5pgskp1y" path="res://addons/@fumohouse/main/ui/main_screen.gd" id="5_qhi0j"]
 [ext_resource type="Texture2D" uid="uid://cly828ija347l" path="res://addons/@fumohouse/base/assets/textures/logo.png" id="6_utajb"]
 [ext_resource type="FontFile" uid="uid://b84oqonqechq2" path="res://addons/@fumohouse/base/assets/fonts/clarity_city/ClarityCity-Bold.woff2" id="7_vrsnp"]
@@ -17,6 +18,7 @@
 [ext_resource type="PackedScene" uid="uid://by5n53kx2tkhx" path="res://addons/@fumohouse/navigation/components/nav_button_container.tscn" id="14_tgh4f"]
 [ext_resource type="PackedScene" uid="uid://dr32entbvcc4" path="res://addons/@fumohouse/navigation/components/nav_button.tscn" id="15_b6v57"]
 [ext_resource type="PackedScene" uid="uid://croenlf3yyt7h" path="res://addons/@fumohouse/music/music_controller.tscn" id="16_v08wt"]
+[ext_resource type="PackedScene" uid="uid://d4h8y2vq573ow" path="res://addons/@fumohouse/navigation/character_editor/nav_character.tscn" id="18_lqqwp"]
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_ujcgd"]
 
@@ -76,7 +78,11 @@ layout_mode = 1
 visible = false
 layout_mode = 1
 
-[node name="MainScreen" type="Control" parent="Screens" index="2"]
+[node name="CharacterEditorScreen" parent="Screens" index="2" instance=ExtResource("5_eq6r0")]
+visible = false
+layout_mode = 1
+
+[node name="MainScreen" type="Control" parent="Screens" index="3"]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
@@ -263,6 +269,21 @@ offset_right = -60.0
 offset_bottom = 148.0
 grow_horizontal = 0
 pivot_offset = Vector2(250, 42)
+
+[node name="NavCharacter" parent="Screens/MainScreen" index="3" instance=ExtResource("18_lqqwp")]
+unique_name_in_owner = true
+layout_mode = 1
+anchors_preset = 6
+anchor_left = 1.0
+anchor_top = 0.5
+anchor_right = 1.0
+anchor_bottom = 0.5
+offset_left = -293.0
+offset_top = -150.5
+offset_right = -53.0
+offset_bottom = 130.5
+grow_horizontal = 0
+grow_vertical = 2
 
 [node name="Dim" type="ColorRect" parent="." index="3"]
 visible = false

--- a/addons/@fumohouse/main/ui/main_screen.gd
+++ b/addons/@fumohouse/main/ui/main_screen.gd
@@ -4,10 +4,14 @@ const MusicController = preload("res://addons/@fumohouse/music/music_controller.
 const NavButtonContainer = preload(
 	"res://addons/@fumohouse/navigation/components/nav_button_container.gd"
 )
+const NavCharacter := preload(
+	"res://addons/@fumohouse/navigation/character_editor/nav_character.gd"
+)
 
 @onready var _non_navigation: Control = $NonNavigation
 @onready var _main_buttons: NavButtonContainer = $MainButtons
 @onready var _music_controller: MusicController = $MusicController
+@onready var _nav_character: NavCharacter = $NavCharacter
 
 @onready var _top_bar: Control = $NonNavigation/TopBar
 @onready var _version_label: Control = $NonNavigation/VersionLabel
@@ -25,6 +29,7 @@ func nav_hide():
 	_top_bar.position.y = _top_bar_target_y(false)
 	_version_label.position.x = _version_label_target_x(false)
 	_music_controller.nav_hide()
+	_nav_character.nav_hide()
 
 
 func nav_show():
@@ -33,6 +38,7 @@ func nav_show():
 	_top_bar.position.y = _top_bar_target_y(true)
 	_version_label.position.x = _version_label_target_x(true)
 	_music_controller.nav_show()
+	_nav_character.nav_show()
 
 
 func nav_transition(vis: bool):
@@ -52,6 +58,7 @@ func nav_transition(vis: bool):
 	_main_buttons.nav_transition(vis)
 	if not vis:
 		_music_controller.nav_transition(false)
+	_nav_character.nav_transition(vis)
 
 	return tween
 

--- a/addons/@fumohouse/navigation/character_editor/character_editor.tscn
+++ b/addons/@fumohouse/navigation/character_editor/character_editor.tscn
@@ -1,0 +1,45 @@
+[gd_scene load_steps=6 format=3 uid="uid://bdohqbssyckea"]
+
+[ext_resource type="PackedScene" uid="uid://dmk1xv60inwsy" path="res://addons/@fumohouse/navigation/screen_base_layout.tscn" id="1_nwhkr"]
+[ext_resource type="Script" uid="uid://d0jgu558ioq1e" path="res://addons/@fumohouse/common/nodes/radio_button_container.gd" id="2_nwhkr"]
+[ext_resource type="PackedScene" uid="uid://b8w13u5smtchn" path="res://addons/@fumohouse/fumo/character_editor/character_editor_preview.tscn" id="3_87xhq"]
+[ext_resource type="PackedScene" uid="uid://4gntby41idbe" path="res://addons/@fumohouse/fumo/character_editor/character_editor_presets.tscn" id="5_gyx0o"]
+[ext_resource type="PackedScene" uid="uid://bofgx233q1y7y" path="res://addons/@fumohouse/fumo/character_editor/character_editor_custom.tscn" id="5_rkn1g"]
+
+[node name="CharacterEditorScreen" node_paths=PackedStringArray("tabs", "tab_content") instance=ExtResource("1_nwhkr")]
+tabs = NodePath("TopBar/Tabs")
+tab_content = NodePath("Contents/MarginContainer/HBoxContainer/TabContent")
+
+[node name="Title" parent="TopBar" index="0"]
+text = "Character Editor"
+
+[node name="Tabs" type="HBoxContainer" parent="TopBar" index="1"]
+layout_mode = 2
+theme_override_constants/separation = 16
+script = ExtResource("2_nwhkr")
+
+[node name="Presets" type="Button" parent="TopBar/Tabs" index="0"]
+custom_minimum_size = Vector2(128, 0)
+layout_mode = 2
+text = "Presets"
+
+[node name="Custom" type="Button" parent="TopBar/Tabs" index="1"]
+custom_minimum_size = Vector2(128, 0)
+layout_mode = 2
+text = "Custom"
+
+[node name="HBoxContainer" type="HBoxContainer" parent="Contents/MarginContainer" index="0"]
+layout_mode = 2
+
+[node name="Preview" parent="Contents/MarginContainer/HBoxContainer" index="0" instance=ExtResource("3_87xhq")]
+layout_mode = 2
+
+[node name="TabContent" type="Control" parent="Contents/MarginContainer/HBoxContainer" index="1"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="Presets" parent="Contents/MarginContainer/HBoxContainer/TabContent" index="0" instance=ExtResource("5_gyx0o")]
+layout_mode = 1
+
+[node name="Custom" parent="Contents/MarginContainer/HBoxContainer/TabContent" index="1" instance=ExtResource("5_rkn1g")]
+layout_mode = 1

--- a/addons/@fumohouse/navigation/character_editor/nav_character.gd
+++ b/addons/@fumohouse/navigation/character_editor/nav_character.gd
@@ -1,0 +1,59 @@
+extends Control
+
+signal edit_pressed
+
+const CharacterViewport := preload(
+	"res://addons/@fumohouse/fumo/character_editor/character_viewport.gd"
+)
+const MenuUtils := preload("../menu_utils.gd")
+
+var _tween: Tween
+
+@onready var _fumo_appearances: FumoAppearances = FumoAppearances.get_singleton()
+
+@onready var _character_viewport: CharacterViewport = %CharacterViewport
+@onready var _edit_button: Button = %EditButton
+
+
+func _ready():
+	_edit_button.pressed.connect(edit_pressed.emit)
+
+	_load_appearance()
+	_fumo_appearances.active_changed.connect(_load_appearance)
+
+
+func nav_hide():
+	scale = Vector2(0, 1)
+	modulate = Color.TRANSPARENT
+
+
+func nav_show():
+	scale = Vector2.ONE
+	modulate = Color.WHITE
+
+
+func nav_transition(vis: bool):
+	if _tween:
+		_tween.kill()
+
+	visible = true
+
+	var tween := MenuUtils.common_tween(self, vis)
+
+	tween.tween_property(
+		self, "scale", Vector2.ONE if vis else Vector2(0, 1), MenuUtils.TRANSITION_DURATION
+	)
+	tween.parallel().tween_property(
+		self, "modulate", Color.WHITE if vis else Color.TRANSPARENT, MenuUtils.TRANSITION_DURATION
+	)
+
+	_tween = tween
+
+	if not vis:
+		await tween.finished
+		visible = false
+
+
+func _load_appearance():
+	_character_viewport.character.appearance_manager.appearance = _fumo_appearances.active
+	_character_viewport.character.appearance_manager.load_appearance()

--- a/addons/@fumohouse/navigation/character_editor/nav_character.gd.uid
+++ b/addons/@fumohouse/navigation/character_editor/nav_character.gd.uid
@@ -1,0 +1,1 @@
+uid://dile6cj36yd5k

--- a/addons/@fumohouse/navigation/character_editor/nav_character.tscn
+++ b/addons/@fumohouse/navigation/character_editor/nav_character.tscn
@@ -1,0 +1,21 @@
+[gd_scene load_steps=3 format=3 uid="uid://d4h8y2vq573ow"]
+
+[ext_resource type="Script" uid="uid://dile6cj36yd5k" path="res://addons/@fumohouse/navigation/character_editor/nav_character.gd" id="1_p3kp7"]
+[ext_resource type="PackedScene" uid="uid://d4hwbq0e54jt4" path="res://addons/@fumohouse/fumo/character_editor/character_viewport.tscn" id="2_vu4gi"]
+
+[node name="NavCharacter" type="VBoxContainer"]
+offset_right = 240.0
+offset_bottom = 281.0
+pivot_offset = Vector2(240, 140.5)
+script = ExtResource("1_p3kp7")
+
+[node name="CharacterViewport" parent="." instance=ExtResource("2_vu4gi")]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="EditButton" type="Button" parent="."]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(96, 0)
+layout_mode = 2
+size_flags_horizontal = 4
+text = "Edit"

--- a/addons/@fumohouse/navigation/module.tres
+++ b/addons/@fumohouse/navigation/module.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" script_class="ModuleManifest" load_steps=6 format=3 uid="uid://d1u5fvuqsj17m"]
+[gd_resource type="Resource" script_class="ModuleManifest" load_steps=7 format=3 uid="uid://d1u5fvuqsj17m"]
 
 [ext_resource type="Script" uid="uid://bv6m4s88g0oi6" path="res://addons/@fumohouse/base/module_autoload.gd" id="1_vwot4"]
 [ext_resource type="Script" uid="uid://cyriemmrcefgc" path="res://addons/@fumohouse/base/module_dependency.gd" id="2_2mwwu"]
@@ -14,7 +14,12 @@ script = ExtResource("2_2mwwu")
 name = &"@fumohouse/config"
 metadata/_custom_type_script = "uid://cyriemmrcefgc"
 
+[sub_resource type="Resource" id="Resource_7m0pi"]
+script = ExtResource("2_2mwwu")
+name = &"@fumohouse/fumo"
+metadata/_custom_type_script = "uid://cyriemmrcefgc"
+
 [resource]
 script = ExtResource("3_7m0pi")
-dependencies = Array[ExtResource("2_2mwwu")]([SubResource("Resource_vwot4"), SubResource("Resource_2mwwu")])
+dependencies = Array[ExtResource("2_2mwwu")]([SubResource("Resource_vwot4"), SubResource("Resource_2mwwu"), SubResource("Resource_7m0pi")])
 metadata/_custom_type_script = "uid://c5kqgift21f1k"

--- a/addons/@fumohouse/world/game_menu/game_menu.gd
+++ b/addons/@fumohouse/world/game_menu/game_menu.gd
@@ -3,6 +3,9 @@ extends "res://addons/@fumohouse/navigation/nav_menu.gd"
 ## Other nodes (e.g., [CameraController]) respond to menu opening.
 signal opened
 
+const NavCharacter := preload(
+	"res://addons/@fumohouse/navigation/character_editor/nav_character.gd"
+)
 const BLUR_PARAM := "shader_parameter/blur"
 const DIM_PARAM := "shader_parameter/dim"
 
@@ -15,9 +18,12 @@ var _tween: Tween
 @onready var _options_button: Button = %OptionsButton
 @onready var _leave_button: Button = %LeaveButton
 
+@onready var _nav_character: NavCharacter = %NavCharacter
+
 @onready var _main_screen: TransitionElement = $Screens/MenuScreen
 @onready var _options_screen: TransitionElement = $Screens/OptionsScreen
 @onready var _leave_screen: TransitionElement = $Screens/LeaveScreen
+@onready var _char_edit_screen: TransitionElement = $Screens/CharacterEditorScreen
 
 @onready var _blur_background: Control = $Blur
 @onready var _blur_mat: ShaderMaterial = _blur_background.material
@@ -29,6 +35,8 @@ func _ready():
 	_continue_button.pressed.connect(func(): nav_transition(false))
 	_options_button.pressed.connect(func(): switch_screen(_options_screen))
 	_leave_button.pressed.connect(_on_leave_button_pressed)
+
+	_nav_character.edit_pressed.connect(switch_screen.bind(_char_edit_screen))
 
 	nav_hide()
 

--- a/addons/@fumohouse/world/game_menu/game_menu.tscn
+++ b/addons/@fumohouse/world/game_menu/game_menu.tscn
@@ -1,14 +1,16 @@
-[gd_scene load_steps=16 format=3 uid="uid://bjlyq7kguqj6c"]
+[gd_scene load_steps=18 format=3 uid="uid://bjlyq7kguqj6c"]
 
 [ext_resource type="PackedScene" uid="uid://ctxaywfcdgbmw" path="res://addons/@fumohouse/navigation/nav_menu.tscn" id="1_tge01"]
 [ext_resource type="Script" uid="uid://b83el535hlsj4" path="res://addons/@fumohouse/world/game_menu/game_menu.gd" id="2_8xol2"]
 [ext_resource type="Shader" uid="uid://cfejetqo4tpot" path="res://addons/@fumohouse/common/resources/materials/ui_blur.gdshader" id="3_ccw7w"]
 [ext_resource type="PackedScene" uid="uid://c55ax8y8twfnj" path="res://addons/@fumohouse/navigation/options_screen/options_screen.tscn" id="4_itoxh"]
+[ext_resource type="PackedScene" uid="uid://bdohqbssyckea" path="res://addons/@fumohouse/navigation/character_editor/character_editor.tscn" id="5_bbkib"]
 [ext_resource type="Script" uid="uid://b08p3vh3shv1n" path="res://addons/@fumohouse/navigation/transition_element.gd" id="5_tvd1v"]
 [ext_resource type="Script" uid="uid://dyygcwyhv7iek" path="res://addons/@fumohouse/world/game_menu/menu_screen.gd" id="6_4uur8"]
 [ext_resource type="PackedScene" uid="uid://by5n53kx2tkhx" path="res://addons/@fumohouse/navigation/components/nav_button_container.tscn" id="7_cpy6s"]
 [ext_resource type="PackedScene" uid="uid://ds5d313nse56r" path="res://addons/@fumohouse/world/game_menu/game_menu_button.tscn" id="8_uvyrv"]
 [ext_resource type="PackedScene" uid="uid://croenlf3yyt7h" path="res://addons/@fumohouse/music/music_controller.tscn" id="9_bsq5a"]
+[ext_resource type="PackedScene" uid="uid://d4h8y2vq573ow" path="res://addons/@fumohouse/navigation/character_editor/nav_character.tscn" id="11_bbkib"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_itoxh"]
 resource_local_to_scene = true
@@ -50,7 +52,11 @@ mouse_filter = 2
 visible = false
 layout_mode = 1
 
-[node name="LeaveScreen" type="PanelContainer" parent="Screens" index="1"]
+[node name="CharacterEditorScreen" parent="Screens" index="1" instance=ExtResource("5_bbkib")]
+visible = false
+layout_mode = 1
+
+[node name="LeaveScreen" type="PanelContainer" parent="Screens" index="2"]
 visible = false
 custom_minimum_size = Vector2(280, 70)
 layout_mode = 1
@@ -73,7 +79,7 @@ text = "Please wait…"
 label_settings = SubResource("LabelSettings_4uur8")
 horizontal_alignment = 1
 
-[node name="MenuScreen" type="Control" parent="Screens" index="2"]
+[node name="MenuScreen" type="Control" parent="Screens" index="3"]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
@@ -186,3 +192,18 @@ offset_bottom = -96.0
 grow_horizontal = 0
 grow_vertical = 0
 pivot_offset = Vector2(250, 0)
+
+[node name="NavCharacter" parent="Screens/MenuScreen" index="4" instance=ExtResource("11_bbkib")]
+unique_name_in_owner = true
+layout_mode = 1
+anchors_preset = 6
+anchor_left = 1.0
+anchor_top = 0.5
+anchor_right = 1.0
+anchor_bottom = 0.5
+offset_left = -293.0
+offset_top = -150.5
+offset_right = -53.0
+offset_bottom = 130.5
+grow_horizontal = 0
+grow_vertical = 2

--- a/addons/@fumohouse/world/game_menu/menu_screen.gd
+++ b/addons/@fumohouse/world/game_menu/menu_screen.gd
@@ -1,10 +1,12 @@
 extends "res://addons/@fumohouse/navigation/transition_element.gd"
 
+const MusicController = preload("res://addons/@fumohouse/music/music_controller.gd")
 const NavButtonContainer = preload(
 	"res://addons/@fumohouse/navigation/components/nav_button_container.gd"
 )
-
-const MusicController = preload("res://addons/@fumohouse/music/music_controller.gd")
+const NavCharacter := preload(
+	"res://addons/@fumohouse/navigation/character_editor/nav_character.gd"
+)
 
 @onready var _gradient_background: Control = $GradientBackground
 @onready var _title: Control = $Contents/Title
@@ -12,6 +14,7 @@ const MusicController = preload("res://addons/@fumohouse/music/music_controller.
 @onready var _bottom_bar: Control = $BottomBar
 @onready var _world_name: Label = %WorldName
 @onready var _music_controller: MusicController = $MusicController
+@onready var _nav_character: NavCharacter = $NavCharacter
 
 
 func _ready():
@@ -28,6 +31,7 @@ func nav_hide():
 	_bottom_bar.modulate = Color.TRANSPARENT
 	_bottom_bar.position.y = _bottom_bar_target_y(false)
 	_music_controller.nav_hide()
+	_nav_character.nav_hide()
 
 
 func nav_show():
@@ -37,6 +41,7 @@ func nav_show():
 	_bottom_bar.modulate = Color.WHITE
 	_bottom_bar.position.y = _bottom_bar_target_y(true)
 	_music_controller.nav_show()
+	_nav_character.nav_show()
 
 
 func nav_transition(vis: bool) -> Tween:
@@ -58,6 +63,7 @@ func nav_transition(vis: bool) -> Tween:
 
 	_nav_buttons.nav_transition(vis)
 	_music_controller.nav_transition(vis)
+	_nav_character.nav_transition(vis)
 
 	return tween
 

--- a/addons/@fumohouse/world/nodes/character_manager_base.gd
+++ b/addons/@fumohouse/world/nodes/character_manager_base.gd
@@ -8,10 +8,17 @@ extends Node3D
 @export var debug_character: DebugCharacter
 
 
-## Spawn a character with the given [param appearance] and
-## [param char_transform] (either a [Transform3D] or [code]null[/code], where
-## the default position or spawnpoint(s) should be used.
-func _spawn_character(appearance: Appearance, char_transform: Variant) -> Node3D:
+## Loads [param appearance] into the loaded character, does nothing if no local
+## character is present.
+func _load_appearance(appearance: Appearance):
+	return null
+
+
+## Spawn a character with the given [param appearance] (or [code]null[/code] for
+## the default), and [param char_transform] (either a [Transform3D] or
+## [code]null[/code], where the default position or spawnpoint(s) should be
+## used).
+func _spawn_character(appearance: Appearance = null, char_transform: Variant = null) -> Node3D:
 	return null
 
 

--- a/addons/@fumohouse/world/world_manager.gd
+++ b/addons/@fumohouse/world/world_manager.gd
@@ -98,11 +98,7 @@ func start_singleplayer(id: String):
 	if not world:
 		return
 
-	# TODO
-	const DEFAULT_APPEARANCE := preload(
-		"res://addons/@fumohouse/fumo_models/resources/presets/doremy.tres"
-	)
-	_current_char_manager._spawn_character(DEFAULT_APPEARANCE, null)
+	_current_char_manager._spawn_character()
 
 
 ## Leave the current world.


### PR DESCRIPTION
This adds a fumo selection screen to the game menu (esc while in-game), currently only selection of preset appearances is supported.

With the Appearance system in place it is possible to design an UI to allow customization of faces and/or individual fumo parts (the latter adds a lot of room for error in terms of consistency over time however, but at least hats could work well).

The current implementation in FumoSelect does not integrate very well with the modules system currently in place, the intent was to aim for a basic functional example with the internals currently in place (or at least as I put them together). Integration issues include:

- Appearance presets are only loaded from the `addons/@fumohouse` module. This also appears to be an issue with the existing FumoPartDatabase implementation (for part data at least), the logic can be split into a separate method (just `scan_dir` works) to ease later integration if needed. One approach would be to move scanning to the modules system, if applicable.
- The CharacterManager is retrieved via a hardcoded path to the Playground, adding a singleton for the CharacterManager could work as a solution.

Additionally, CharacterManager does not appear to have a mechanism to respawn the player fumo in its original spot, it may be best to do so on the callee if a local character already exists. This does go a bit out of scope from the UI design and relevant infrastructure a bit however.

There are a few visual quirks in the FumoSelect UI/UX: it lacks animations and is too small, I think it would function well as a separate screen (kind of like how the Options menu is presented).

One concern with the existing internals is that there is no categorization for Appearances in place, for example Scuffed Become Fumo roughly has three groups (Touhou/Non-touhou/Unlockables, with the last one taking precedence), a tags system may work for characters (i.e Doremy having tags `touhou/lolk`, Miku having `vocaloid`, etc.) if matching this UI design 1:1 is not necessary. IIRC Fumo Land Live used a flat list, it seemed to be sorted manually. This is mostly just brainstorming to avoid retrofitting a filter system later.

Do note of any issues with this design, implementation or anything else I may have missed.